### PR TITLE
fix: Upgrade lru-cache package to fix projen upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1711,9 +1711,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.0.tgz",
-          "integrity": "sha512-3W9Irr9YR2ZHJbfRr/hj8VtzqH7DugwWyHONyDByP6PLS/YJV7GTX5dDYS+qFe/LkVfnCjtk6vkVsxxKGol6jQ==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.1.tgz",
+          "integrity": "sha512-cRffBiTW8s73eH4aTXqBcTLU0xQnwGV3/imttRHGWCrbergmnK4D6JXQd8qin5z43HnDwRI+o7mVW0LEB+tpAw==",
           "dev": true
         }
       }
@@ -2683,9 +2683,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.0.tgz",
-          "integrity": "sha512-3W9Irr9YR2ZHJbfRr/hj8VtzqH7DugwWyHONyDByP6PLS/YJV7GTX5dDYS+qFe/LkVfnCjtk6vkVsxxKGol6jQ==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.1.tgz",
+          "integrity": "sha512-cRffBiTW8s73eH4aTXqBcTLU0xQnwGV3/imttRHGWCrbergmnK4D6JXQd8qin5z43HnDwRI+o7mVW0LEB+tpAw==",
           "dev": true
         }
       }
@@ -6495,9 +6495,9 @@
           }
         },
         "lru-cache": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.0.tgz",
-          "integrity": "sha512-3W9Irr9YR2ZHJbfRr/hj8VtzqH7DugwWyHONyDByP6PLS/YJV7GTX5dDYS+qFe/LkVfnCjtk6vkVsxxKGol6jQ==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.1.tgz",
+          "integrity": "sha512-cRffBiTW8s73eH4aTXqBcTLU0xQnwGV3/imttRHGWCrbergmnK4D6JXQd8qin5z43HnDwRI+o7mVW0LEB+tpAw==",
           "dev": true
         }
       }
@@ -7080,9 +7080,9 @@
           }
         },
         "lru-cache": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.0.tgz",
-          "integrity": "sha512-3W9Irr9YR2ZHJbfRr/hj8VtzqH7DugwWyHONyDByP6PLS/YJV7GTX5dDYS+qFe/LkVfnCjtk6vkVsxxKGol6jQ==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.1.tgz",
+          "integrity": "sha512-cRffBiTW8s73eH4aTXqBcTLU0xQnwGV3/imttRHGWCrbergmnK4D6JXQd8qin5z43HnDwRI+o7mVW0LEB+tpAw==",
           "dev": true
         }
       }
@@ -8172,9 +8172,9 @@
           }
         },
         "lru-cache": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.0.tgz",
-          "integrity": "sha512-3W9Irr9YR2ZHJbfRr/hj8VtzqH7DugwWyHONyDByP6PLS/YJV7GTX5dDYS+qFe/LkVfnCjtk6vkVsxxKGol6jQ==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.1.tgz",
+          "integrity": "sha512-cRffBiTW8s73eH4aTXqBcTLU0xQnwGV3/imttRHGWCrbergmnK4D6JXQd8qin5z43HnDwRI+o7mVW0LEB+tpAw==",
           "dev": true
         },
         "normalize-package-data": {


### PR DESCRIPTION
projen upgrade command is failing because of a bug introduced in version 7.7.0 of lru-cache. See https://github.com/isaacs/node-lru-cache/pull/217 for details.